### PR TITLE
fix: allow write slash after number

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,4 @@ npm-debug.log
 Gemfile.lock
 browserStack.json
 browserStack.zip
-build
+

--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,6 @@
 npm-debug.log
 /_site
 Gemfile.lock
-
 browserStack.json
-
 browserStack.zip
+build

--- a/InputElement.js
+++ b/InputElement.js
@@ -164,12 +164,15 @@ var InputElement = React.createClass({
             var prefix = this.getPrefix();
             var prefixLen = prefix.length;
             value = this.insertRawSubstr("", value, 0);
-            while (value.length > prefixLen && this.isPermanentChar(value.length - 1)) {
-                value = value.slice(0, value.length - 1);
-            }
-
+         
             if (value.length < prefixLen) {
                 value = prefix;
+            }
+
+            var maskLen = mask.length;
+
+            while (value.length < maskLen && this.isPermanentChar(value.length)) {
+                value += mask[value.length];
             }
 
             return value;
@@ -621,7 +624,7 @@ var InputElement = React.createClass({
         var prefixLen = this.getPrefix().length;
         var clearedValue;
 
-        if (valueLen > oldValueLen) {
+        if (valueLen >= oldValueLen) {
             var substrLen = valueLen - oldValueLen;
             var startPos = selection.end - substrLen;
             var enteredSubstr = value.substr(startPos, substrLen);
@@ -638,7 +641,9 @@ var InputElement = React.createClass({
             clearedValue = this.clearRange(value, startPos, maskLen - startPos);
             clearedValue = this.insertRawSubstr(clearedValue, enteredSubstr, caretPos);
 
-            value = this.insertRawSubstr(oldValue, enteredSubstr, caretPos);
+            value = enteredSubstr ?
+                this.insertRawSubstr(oldValue, enteredSubstr, caretPos) :
+                clearedValue;
 
             if (substrLen !== 1 || (caretPos >= prefixLen && caretPos < lastEditablePos)) {
                 caretPos = this.getFilledLength(clearedValue);

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "react-input-mask",
+  "name": "@digital-origin/react-input-mask",
   "description": "Masked input component for React",
   "version": "0.7.9",
   "homepage": "https://github.com/sanniassin/react-input-mask",

--- a/tests/input-test.js
+++ b/tests/input-test.js
@@ -170,7 +170,8 @@ describe('Input', () => {
         inputNode.value = 'aaaa';
         input.setCaretPos(4);
         TestUtils.Simulate.change(inputNode);
-        expect(inputNode.value).toEqual('aaaa');
+        console.log(inputNode.value);
+        expect(inputNode.value).toEqual('aaaa ');
         expect(input.getCaretPos()).toEqual(4);
 
         inputNode.value = 'aaaaa';

--- a/tests/input-test.js
+++ b/tests/input-test.js
@@ -170,7 +170,6 @@ describe('Input', () => {
         inputNode.value = 'aaaa';
         input.setCaretPos(4);
         TestUtils.Simulate.change(inputNode);
-        console.log(inputNode.value);
         expect(inputNode.value).toEqual('aaaa ');
         expect(input.getCaretPos()).toEqual(4);
 


### PR DESCRIPTION
#### :tophat: What? Why?

For the user is not obvious if should write or not slash. It should be auto written.

#### :ghost: GIF
![](https://media.giphy.com/media/Fz3sqZZLsOCGI/giphy.gif)
